### PR TITLE
feat: dispatch htmx:oobErrorNoTarget event when OOB target not found

### DIFF
--- a/src/htmx/processor.mbt
+++ b/src/htmx/processor.mbt
@@ -152,9 +152,10 @@ extern "js" fn create_response_callback(
   #|    if (responseText !== null) {
   #|      const select_val = element.getAttribute("hx-select") || element.getAttribute("data-hx-select");
   #|      let final_content = responseText;
+  #|      const parser = new DOMParser();
+  #|      const doc = parser.parseFromString(responseText, 'text/html');
+
   #|      if (select_val) {
-  #|        const parser = new DOMParser();
-  #|        const doc = parser.parseFromString(responseText, 'text/html');
   #|        const selected = doc.querySelector(select_val);
   #|        if (selected) {
   #|          final_content = selected.outerHTML;
@@ -162,6 +163,76 @@ extern "js" fn create_response_callback(
   #|          final_content = "";
   #|        }
   #|      }
+
+  #|      // If select was used, re-parse for OOB processing
+  #|      let oobDoc = doc;
+  #|      if (select_val) {
+  #|        oobDoc = parser.parseFromString(final_content, 'text/html');
+  #|      }
+  #|
+  #|      // Handle OOB swaps (hx-swap-oob)
+  #|      const oobElements = oobDoc.querySelectorAll('[hx-swap-oob], [data-hx-swap-oob]');
+  #|      for (const oobEl of oobElements) {
+  #|        const oobVal = oobEl.getAttribute('hx-swap-oob') || oobEl.getAttribute('data-hx-swap-oob') || 'true';
+  #|        let targetSelector = null;
+  #|        let swapStyle = 'innerHTML'; // default
+  #|
+  #|        // Parse OOB specification
+  #|        if (oobVal === 'true') {
+  #|          swapStyle = 'outerHTML';
+  #|          const id = oobEl.getAttribute('id');
+  #|          if (id) targetSelector = '#' + CSS.escape(id);
+  #|        } else if (oobVal.includes(':')) {
+  #|          const parts = oobVal.split(':');
+  #|          swapStyle = parts[0] || 'innerHTML';
+  #|          targetSelector = parts[1];
+  #|        } else {
+  #|          swapStyle = oobVal;
+  #|          const id = oobEl.getAttribute('id');
+  #|          if (id) targetSelector = '#' + CSS.escape(id);
+  #|        }
+  #|
+  #|        // Handle delete style
+  #|        if (swapStyle === 'delete') {
+  #|          if (targetSelector) {
+  #|            const targets = document.querySelectorAll(targetSelector);
+  #|            for (const targetEl of targets) {
+  #|              targetEl.remove();
+  #|            }
+  #|          }
+  #|          oobEl.remove();
+  #|          continue;
+  #|        }
+  #|
+  #|        // Find and swap target
+  #|        if (targetSelector) {
+  #|          const targets = document.querySelectorAll(targetSelector);
+  #|          if (targets.length === 0) {
+  #|            // No target found, dispatch error event
+  #|            const evt = new CustomEvent('htmx:oobErrorNoTarget', {
+  #|              bubbles: true,
+  #|              cancelable: true,
+  #|              detail: { content: oobEl }
+  #|            });
+  #|            document.body.dispatchEvent(evt);
+  #|          } else {
+  #|            // Swap into all matching targets
+  #|            for (const targetEl of targets) {
+  #|              if (swapStyle === 'innerHTML') {
+  #|                targetEl.innerHTML = oobEl.innerHTML;
+  #|              } else if (swapStyle === 'outerHTML') {
+  #|                targetEl.outerHTML = oobEl.outerHTML;
+  #|              }
+  #|            }
+  #|          }
+  #|        }
+  #|
+  #|        // Remove OOB element from response
+  #|        oobEl.remove();
+  #|      }
+  #|
+  #|      // Get final content after OOB removal
+  #|      final_content = oobDoc.body.innerHTML;
   #|
   #|      // Simple innerHTML swap
   #|      target.innerHTML = final_content;

--- a/test/attributes/hx-swap-oob.js
+++ b/test/attributes/hx-swap-oob.js
@@ -348,7 +348,7 @@ describe('hx-swap-oob attribute', function() {
     })
   }
 
-  it.skip('triggers htmx:oobErrorNoTarget when no targets found', function(done) {
+  it('triggers htmx:oobErrorNoTarget when no targets found', function(done) {
     // this test fails right now because when targets not found it returns an empty array which makes it miss the event as it should be if (targets.length)
     this.server.respondWith('GET', '/test', "Clicked<div id='nonexistent' hx-swap-oob='true'>Swapped</div>")
     var div = make('<div hx-get="/test">click me</div>')


### PR DESCRIPTION
## Summary

Implements Issue #4: OOB swapでターゲット不在時に htmx:oobErrorNoTarget をdispatch

## Changes

- Add OOB swap processing in \`processor.mbt\`'s \`create_response_callback\` FFI
- Dispatch \`htmx:oobErrorNoTarget\` event when OOB target is not found
- Support \`innerHTML\` and \`outerHTML\` swap styles for OOB elements
- Support \`delete\` style for OOB elements
- Handle special characters in IDs using \`CSS.escape()\`
- Enable "triggers htmx:oobErrorNoTarget when no targets found" test

## Event Details

- Event name: \`htmx:oobErrorNoTarget\`
- \`bubbles: true\`, \`cancelable: true\`
- \`detail.content\`: the OOB element that couldn't find a target
- Dispatched on \`document.body\`

## Test Results

- Target test "triggers htmx:oobErrorNoTarget when no targets found": ✅ PASSED
- Overall: 56 passed, 12 failed (12 failures are pre-existing web components issues)