### PR TITLE
feat: catch script exceptions to prevent breaking rendering (Issue #2)

### DIFF
--- a/src/htmx/processor.mbt
+++ b/src/htmx/processor.mbt
@@ -154,7 +154,6 @@ extern "js" fn create_response_callback(
   #|      let final_content = responseText;
   #|      const parser = new DOMParser();
   #|      const doc = parser.parseFromString(responseText, 'text/html');
-
   #|      if (select_val) {
   #|        const selected = doc.querySelector(select_val);
   #|        if (selected) {
@@ -163,7 +162,6 @@ extern "js" fn create_response_callback(
   #|          final_content = "";
   #|        }
   #|      }
-
   #|      // If select was used, re-parse for OOB processing
   #|      let oobDoc = doc;
   #|      if (select_val) {
@@ -236,6 +234,23 @@ extern "js" fn create_response_callback(
   #|
   #|      // Simple innerHTML swap
   #|      target.innerHTML = final_content;
+  #|
+  #|      // Evaluate inline scripts after swap (Issue #2)
+  #|      // Only executes scripts with no type or type='text/javascript'
+  #|      // Exceptions are caught to prevent breaking rendering
+  #|      if (window.htmx && window.htmx.config && window.htmx.config.allowEval !== false) {
+  #|        const scripts = target.querySelectorAll('script');
+  #|        for (const script of scripts) {
+  #|          const type = script.getAttribute('type');
+  #|          if (!type || type === 'text/javascript') {
+  #|            try {
+  #|              (new Function(script.textContent))();
+  #|            } catch (e) {
+  #|              console.error('htmx.mbt: Error executing script:', e);
+  #|            }
+  #|          }
+  #|        }
+  #|      }
   #|
   #|      // Handle history API
   #|      const push_val = element.getAttribute("hx-push-url") || element.getAttribute("data-hx-push-url");

--- a/test/core/ajax.js
+++ b/test/core/ajax.js
@@ -725,7 +725,6 @@ describe('Core htmx AJAX Tests', function() {
   })
 
   it('script node exceptions do not break rendering', function() {
-    this.skip('Rendering does not break, but the exception bubbles up and mocha reports it')
     this.server.respondWith('GET', '/test', "clicked<script type='text/javascript'>throw 'foo';</script>")
     var div = make("<div hx-get='/test'></div>")
     div.click()

--- a/test/core/shadowdom.js
+++ b/test/core/shadowdom.js
@@ -771,7 +771,6 @@ describe('Core htmx Shadow DOM Tests', function() {
   })
 
   it('script node exceptions do not break rendering', function() {
-    this.skip('Rendering does not break, but the exception bubbles up and mocha reports it')
     this.server.respondWith('GET', '/test', "clicked<script type='text/javascript'>throw 'foo';</script>")
     var div = make("<div hx-get='/test'></div>")
     div.click()


### PR DESCRIPTION
## Summary
- Swap 後に inline script を評価する機能を追加
- 例外が発生しても描画が壊れないように try/catch で例外をキャッチ
- `htmx.config.allowEval` 設定を尊重
- type 属性が未設定または 'text/javascript' のスクリプトのみ実行

## Test plan
- [x] ajax.js の "script node exceptions do not break rendering" テストがパス
- [x] moon fmt でフォーマット済み
- [x] ビルドが成功

Fixes #2