### PR TITLE
feat: dispatch htmx:oobErrorNoTarget when OOB target not found (Issue #4)

### DIFF
--- a/src/htmx/response.mbt
+++ b/src/htmx/response.mbt
@@ -49,7 +49,12 @@ fn process_oob_swaps(container : @dom.Element) -> Unit {
         // Remove from response content
         el.remove()
       }
-      None => ()
+      None => {
+        // Dispatch error event when target not found
+        dispatch_oob_error_no_target(el)
+        // Still remove OOB element from response content
+        el.remove()
+      }
     }
   }
 }
@@ -63,3 +68,15 @@ extern "js" fn get_inner_html(element : @dom.Element) -> String =
 /// Get outerHTML property
 extern "js" fn get_outer_html(element : @dom.Element) -> String =
   #|(el) => el.outerHTML
+
+///|
+/// Dispatch htmx:oobErrorNoTarget event when OOB target not found
+extern "js" fn dispatch_oob_error_no_target(oob_el : @dom.Element) -> Unit =
+  #|(oobEl) => {
+  #|  const evt = new CustomEvent('htmx:oobErrorNoTarget', {
+  #|    bubbles: true,
+  #|    cancelable: true,
+  #|    detail: { content: oobEl }
+  #|  });
+  #|  document.body.dispatchEvent(evt);
+  #|}


### PR DESCRIPTION
## Summary
- OOB swapでターゲット要素が見つからない場合、`htmx:oobErrorNoTarget` イベントを `document.body` にdispatchする実装を行いました

## Changes
- `src/htmx/response.mbt` に `dispatch_oob_error_no_target` 関数を追加
  - イベント名: `htmx:oobErrorNoTarget`
  - bubbles: true, cancelable: true
  - detail: { content: oobEl }
- `process_oob_swaps` 関数を修正
  - `find_oob_target` が `None` を返した場合にイベントをdispatch
  - ターゲットが見つからない場合でも、OOB要素はレスポンスから削除される

## Test plan
- [x] `npm run test:htmx` で `"triggers htmx:oobErrorNoTarget when no targets found"` テストがパスすることを確認
- [x] `moon info && moon fmt` で型チェックとフォーマットを確認

Closes #4