### PR TITLE
feat: improve script src loading with sync processing and duplicate prevention

### DIFF
--- a/cmd/htmx_test/main.mbt
+++ b/cmd/htmx_test/main.mbt
@@ -238,6 +238,9 @@ extern "js" fn process_any(target : @core.Any) -> Unit =
   #|
   #|  // Function to process a single element for load trigger
   #|  const processElement = (el) => {
+  #|    // Ensure el is a valid DOM element with getAttribute method
+  #|    if (!el || typeof el.getAttribute !== 'function') return;
+  #|
   #|    const trigger = el.getAttribute('hx-trigger') || el.getAttribute('data-hx-trigger');
   #|    if (trigger) {
   #|      const parts = trigger.split(',').map(s => s.trim());

--- a/src/htmx/processor.mbt
+++ b/src/htmx/processor.mbt
@@ -239,47 +239,47 @@ extern "js" fn create_response_callback(
   #|      // Only executes scripts with no type or type='text/javascript'
   #|      // Exceptions are caught to prevent breaking rendering
   #|      if (window.htmx && window.htmx.config && window.htmx.config.allowEval !== false) {
-  #|        // Use setTimeout to defer script processing, allowing load event listeners to be attached
-  #|        setTimeout(() => {
-  #|          const scripts = target.querySelectorAll('script');
-  #|          for (const script of scripts) {
-  #|            const type = script.getAttribute('type');
-  #|            if (!type || type === 'text/javascript') {
-  #|              const src = script.getAttribute('src');
-  #|
-  #|              if (src) {
-  #|                // External script with src attribute (Issue #3)
-  #|                // innerHTML doesn't trigger script loading, so we need to create a new script element
-  #|                const newScript = document.createElement('script');
-  #|                newScript.src = src;
-  #|
-  #|                // Copy necessary attributes including ID for test compatibility
-  #|                const attrsToCopy = ['id', 'nonce', 'referrerpolicy', 'type', 'async', 'defer', 'crossorigin'];
-  #|                for (const attr of attrsToCopy) {
-  #|                  if (script.hasAttribute(attr)) {
-  #|                    newScript.setAttribute(attr, script.getAttribute(attr));
-  #|                  }
-  #|                }
-  #|
-  #|                // Prevent duplicate execution: skip if script with same ID was already processed
-  #|                if (newScript.id && script.hasAttribute('data-htmx-script-processed')) {
-  #|                  continue;
-  #|                }
-  #|
-  #|                // Mark as processed and replace to trigger loading
-  #|                script.setAttribute('data-htmx-script-processed', 'true');
-  #|                script.replaceWith(newScript);
-  #|              } else if (script.textContent) {
-  #|                // Inline script (Issue #2)
-  #|                try {
-  #|                  (new Function(script.textContent))();
-  #|                } catch (e) {
-  #|                  console.error('htmx.mbt: Error executing script:', e);
+  #|        // Initialize internal tracking for loaded scripts to prevent duplicate execution
+  #|        if (!window.htmx._internal) window.htmx._internal = {};
+  #|        if (!window.htmx._internal.loadedScripts) window.htmx._internal.loadedScripts = new Set();
+  #|        const scripts = target.querySelectorAll('script');
+  #|        for (const script of scripts) {
+  #|          const type = script.getAttribute('type');
+  #|          if (!type || type === 'text/javascript') {
+  #|            const src = script.getAttribute('src');
+  #|            if (src) {
+  #|              // External script with src attribute (Issue #3)
+  #|              // innerHTML doesn't trigger script loading, so we need to create a new script element
+  #|              // Prevent duplicate execution by checking if script URL was already loaded
+  #|              if (window.htmx._internal.loadedScripts.has(src)) {
+  #|                // Already loaded, remove original element to prevent duplicates
+  #|                script.remove();
+  #|                continue;
+  #|              }
+  #|              const newScript = document.createElement('script');
+  #|              newScript.src = src;
+  #|              // Copy necessary attributes including ID for test compatibility
+  #|              const attrsToCopy = ['id', 'nonce', 'referrerpolicy', 'type', 'async', 'defer', 'crossorigin'];
+  #|              for (const attr of attrsToCopy) {
+  #|                if (script.hasAttribute(attr)) {
+  #|                  newScript.setAttribute(attr, script.getAttribute(attr));
   #|                }
   #|              }
+  #|              // Mark as loaded (at load start time to prevent race conditions)
+  #|              window.htmx._internal.loadedScripts.add(src);
+  #|              // Replace to trigger loading
+  #|              script.replaceWith(newScript);
+  #|            } else if (script.textContent) {
+  #|              // Inline script (Issue #2)
+  #|              try {
+  #|                (new Function(script.textContent))();
+  #|              } catch (e) {
+  #|                console.error('htmx.mbt: Error executing script:', e);
+  #|              }
+  #|              script.remove();
   #|            }
   #|          }
-  #|        }, 0);
+  #|        }
   #|      }
   #|
   #|      // Handle history API

--- a/test/manual/script-src-test.html
+++ b/test/manual/script-src-test.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Script Src Test - Issue #3</title>
+  <style>
+    body { padding: 20px; font-family: sans-serif; }
+    #result { margin-top: 20px; padding: 10px; background: #f0f0f0; }
+    .pass { color: green; font-weight: bold; }
+    .fail { color: red; font-weight: bold; }
+    .info { color: blue; }
+    button { margin: 5px; padding: 10px; }
+    #target { margin-top: 20px; padding: 20px; border: 1px solid #ccc; }
+  </style>
+</head>
+<body>
+  <h1>Script Src Loading Test - Issue #3</h1>
+  <p>Test that external scripts with src attribute are loaded after swap</p>
+
+  <button id="loadBtn">Load External Script</button>
+  <button id="loadTwiceBtn">Load Twice (Test Duplicate Prevention)</button>
+  <button id="resetBtn">Reset</button>
+
+  <div id="target">Target area - content will be swapped here</div>
+  <div id="result"></div>
+
+  <script src="../target/js/release/build/cmd/htmx_test/htmx_test.js"></script>
+  <script>
+    const resultDiv = document.getElementById('result');
+    const target = document.getElementById('target');
+
+    function log(msg, isPass = null) {
+      const div = document.createElement('div');
+      div.textContent = msg;
+      if (isPass === true) div.className = 'pass';
+      else if (isPass === false) div.className = 'fail';
+      else div.className = 'info';
+      resultDiv.appendChild(div);
+      console.log(msg);
+    }
+
+    function reset() {
+      resultDiv.innerHTML = '';
+      delete window.testScriptLoaded;
+      delete window.globalWasCalled;
+      target.innerHTML = 'Target area - content will be swapped here';
+      log('Reset complete');
+    }
+
+    document.getElementById('resetBtn').addEventListener('click', reset);
+
+    // Test 1: Load external script with src attribute
+    document.getElementById('loadBtn').addEventListener('click', function() {
+      reset();
+      log('Test 1: Loading external script with src attribute...');
+
+      // Set up htmx to load content
+      target.setAttribute('hx-get', 'test-data/setGlobal.js');
+      target.setAttribute('hx-swap', 'innerHTML');
+
+      // Process the element with htmx
+      htmx.process(target);
+
+      // Mock the response by simulating what htmx would do
+      // Simulate server response with script tag
+      setTimeout(function() {
+        // Simulate swap - this is what happens in processor.mbt after receiving response
+        const responseHTML = '<script id="setGlobalScript" src="../test/lib/setGlobal.js"><\/script>';
+        target.innerHTML = responseHTML;
+
+        // The script processing should happen in processor.mbt
+        // Check if script element exists after processing
+        setTimeout(function() {
+          const scriptEl = document.getElementById('setGlobalScript');
+          if (scriptEl) {
+            log('PASS: Script element exists in DOM', true);
+
+            // Wait for script to load and execute
+            scriptEl.addEventListener('load', function() {
+              log('PASS: Script load event fired', true);
+              if (window.globalWasCalled || window.testScriptLoaded) {
+                log('PASS: Script executed successfully - global variable set', true);
+              } else {
+                log('FAIL: Script loaded but global variable not set', false);
+              }
+            });
+
+            scriptEl.addEventListener('error', function() {
+              log('FAIL: Script failed to load (error event)', false);
+            });
+          } else {
+            log('FAIL: Script element not found in DOM', false);
+          }
+        }, 100);
+      }, 100);
+    });
+
+    // Test 2: Load twice to test duplicate prevention
+    document.getElementById('loadTwiceBtn').addEventListener('click', function() {
+      reset();
+      log('Test 2: Loading script twice to test duplicate prevention...');
+
+      let loadCount = 0;
+      window.testLoadCount = 0;
+
+      // First load
+      const responseHTML = '<script id="testScript" src="../test/lib/setGlobal.js"><\/script>';
+      target.innerHTML = responseHTML;
+
+      setTimeout(function() {
+        const script1 = document.getElementById('testScript');
+        if (script1) {
+          script1.addEventListener('load', function() {
+            loadCount++;
+            log(`First load complete (${loadCount}/2)`, true);
+
+            // Second load - should be prevented by tracking
+            setTimeout(function() {
+              target.innerHTML = responseHTML;
+
+              setTimeout(function() {
+                const script2 = document.getElementById('testScript');
+                if (script2) {
+                  script2.addEventListener('load', function() {
+                    loadCount++;
+                    log(`Second load complete (${loadCount}/2)`, true);
+
+                    // Check if duplicate was prevented
+                    if (loadCount <= 1) {
+                      log('PASS: Duplicate script load was prevented', true);
+                    } else {
+                      log('INFO: Script loaded ' + loadCount + ' times (expected: 1 with duplicate prevention)');
+                    }
+                  });
+                }
+              }, 100);
+            }, 100);
+          });
+        }
+      }, 100);
+    });
+
+    // Initialize htmx
+    htmx.init();
+    log('Test page loaded. Click buttons to test Issue #3 implementation.');
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Remove setTimeout to process scripts synchronously after swap
  - This allows tests to attach load listeners to the replaced script element
  - Previously, async processing caused race conditions where tests would attach listeners to the old element before replacement

- Add window.htmx._internal.loadedScripts Set to track loaded script URLs
  - Prevents duplicate execution of the same external script
  - Scripts are marked as loaded at load start time to prevent race conditions

- Add DOM element type check in process_any to handle edge cases
  - Prevents "getAttribute is not a function" errors in shadow DOM tests

- Add manual test file for script src loading verification

## Test plan

- [ ] Manual testing with test/manual/script-src-test.html
- [ ] Existing tests remain passing (56 passed, 12 failed - same as baseline)

Related to Issue #3