### PR TITLE
feat: implement history cache internal API (htmx._) for hx-push-url

### DIFF
--- a/cmd/htmx_test/main.mbt
+++ b/cmd/htmx_test/main.mbt
@@ -467,8 +467,60 @@ fn remove_extension_any(_name_any : @core.Any) -> Unit {
 }
 
 ///|
-fn internal_any(_name_any : @core.Any) -> @core.Any {
+
+///|
+/// Wrapper for saveToHistoryCache - (url, element, title) -> Unit
+fn save_to_history_cache_any(
+  url_any : @core.Any,
+  element_any : @core.Any,
+  title_any : @core.Any,
+) -> @core.Any {
+  let url = as_string(url_any)
+  let title = as_string(title_any)
+  @htmx.save_to_history_cache(url, element_any, title)
   @core.undefined()
+}
+
+///|
+/// Wrapper for getCachedHistory - (url) -> content or null
+fn get_cached_history_any(url_any : @core.Any) -> @core.Any {
+  let url = as_string(url_any)
+  match @htmx.get_cached_history(url) {
+    Some(content) => @core.any(content)
+    None => @core.null()
+  }
+}
+
+///|
+/// Wrapper for restoreHistory - (path) -> Unit
+fn restore_history_any(path_any : @core.Any) -> @core.Any {
+  let path = as_string(path_any)
+  @htmx.restore_history(path)
+  @core.undefined()
+}
+
+///|
+/// Wrapper for normalizePath - (path) -> normalized string
+fn normalize_path_any(path_any : @core.Any) -> @core.Any {
+  let path = as_string(path_any)
+  let normalized = @htmx.normalize_path(path)
+  @core.any(normalized)
+}
+
+///|
+fn internal_any(name_any : @core.Any) -> @core.Any {
+  if @core.is_nullish(name_any) {
+    @core.undefined()
+  } else {
+    let name = as_string(name_any)
+    match name {
+      "saveToHistoryCache" => @core.from_fn3(save_to_history_cache_any)
+      "getCachedHistory" => @core.from_fn1(get_cached_history_any)
+      "restoreHistory" => @core.from_fn1(restore_history_any)
+      "normalizePath" => @core.from_fn1(normalize_path_any)
+      _ => @core.undefined()
+    }
+  }
 }
 
 ///|
@@ -479,6 +531,8 @@ fn make_htmx_object() -> @core.Any {
   htmx_obj._set("version", @core.any("0.1.0-mbt"))
   // Set allowEval to true by default for hx-on functionality
   config_obj._set("allowEval", @core.any(true))
+  config_obj._set("historyCacheSize", @core.any(10))
+  config_obj._set("refreshOnHistoryMiss", @core.any(false))
   htmx_obj._set("config", config_obj)
   htmx_obj._set("cache", cache_obj)
   htmx_obj._set("location", window_location())

--- a/src/htmx/history_cache.mbt
+++ b/src/htmx/history_cache.mbt
@@ -1,0 +1,519 @@
+///|
+/// History cache implementation for htmx
+/// Handles caching of page content in sessionStorage for history navigation
+
+///|
+/// Storage key for history cache in sessionStorage
+const HISTORY_CACHE_KEY : String = "htmx-history-cache"
+
+///|
+/// Normalize a URL path for caching
+/// Uses dummy base URL to handle path-only URLs
+pub fn normalize_path(path : String) -> String {
+  normalize_path_impl(path)
+}
+
+///|
+extern "js" fn normalize_path_impl(path : String) -> String =
+  #|(path) => {
+  #|  try {
+  #|    const url = new URL(path, 'http://x');
+  #|    if (url) {
+  #|      path = url.pathname + url.search;
+  #|    }
+  #|  } catch (e) {
+  #|    // If URL parsing fails, use path as-is
+  #|  }
+  #|  // Remove trailing slash unless it's the index
+  #|  if (path !== '/') {
+  #|    path = path.replace(/\/+$/, '');
+  #|  }
+  #|  return path;
+  #|}
+
+///|
+/// Get history cache size from htmx config
+fn get_cache_size() -> Int {
+  get_cache_size_js()
+}
+
+///|
+extern "js" fn get_cache_size_js() -> Int =
+  #|() => {
+  #|  const size = window.htmx && window.htmx.config && window.htmx.config.historyCacheSize;
+  #|  return (typeof size === 'number') ? size : 10;
+  #|}
+
+///|
+/// Get refreshOnHistoryMiss config value
+fn get_refresh_on_history_miss() -> Bool {
+  get_refresh_on_history_miss_js()
+}
+
+///|
+extern "js" fn get_refresh_on_history_miss_js() -> Bool =
+  #|() => {
+  #|  return !!(window.htmx && window.htmx.config && window.htmx.config.refreshOnHistoryMiss);
+  #|}
+
+///|
+/// Check if sessionStorage is accessible
+fn can_access_session_storage() -> Bool {
+  can_access_session_storage_js()
+}
+
+///|
+extern "js" fn can_access_session_storage_js() -> Bool =
+  #|() => {
+  #|  try {
+  #|    const test = 'htmx:sessionStorageTest';
+  #|    sessionStorage.setItem(test, test);
+  #|    sessionStorage.removeItem(test);
+  #|    return true;
+  #|  } catch (e) {
+  #|    return false;
+  #|  }
+  #|}
+
+///|
+/// Get item from sessionStorage (returns null on error)
+fn session_storage_get(key : String) -> @core.Any {
+  session_storage_get_js(key)
+}
+
+///|
+extern "js" fn session_storage_get_js(key : String) -> @core.Any =
+  #|(key) => {
+  #|  try {
+  #|    return sessionStorage.getItem(key);
+  #|  } catch (e) {
+  #|    return null;
+  #|  }
+  #|}
+
+///|
+/// Set item in sessionStorage (returns false on error)
+fn session_storage_set(key : String, value : @core.Any) -> Bool {
+  session_storage_set_js(key, value)
+}
+
+///|
+extern "js" fn session_storage_set_js(key : String, value : @core.Any) -> Bool =
+  #|(key, value) => {
+  #|  try {
+  #|    sessionStorage.setItem(key, value);
+  #|    return true;
+  #|  } catch (e) {
+  #|    return false;
+  #|  }
+  #|}
+
+///|
+/// Remove item from sessionStorage
+fn session_storage_remove(key : String) -> Unit {
+  session_storage_remove_js(key)
+}
+
+///|
+extern "js" fn session_storage_remove_js(key : String) -> Unit =
+  #|(key) => {
+  #|  try {
+  #|    sessionStorage.removeItem(key);
+  #|  } catch (e) {
+  #|    // Ignore errors
+  #|  }
+  #|}
+
+///|
+/// Get the history element (body or element with hx-history-elt attribute)
+fn get_history_element() -> @dom.Element {
+  get_history_element_js()
+}
+
+///|
+extern "js" fn get_history_element_js() -> @dom.Element =
+  #|() => {
+  #|  const historyElt = document.querySelector('[hx-history-elt],[data-hx-history-elt]');
+  #|  return historyElt || document.body;
+  #|}
+
+///|
+/// Get document title
+fn get_document_title() -> String {
+  get_document_title_js()
+}
+
+///|
+extern "js" fn get_document_title_js() -> String =
+  #|() => document.title
+
+///|
+/// Get current scroll Y position
+fn get_scroll_y() -> Int {
+  get_scroll_y_js()
+}
+
+///|
+extern "js" fn get_scroll_y_js() -> Int =
+  #|() => window.scrollY || 0
+
+///|
+/// Stringify JSON safely (returns null on error)
+fn json_stringify_safe(obj : @core.Any) -> @core.Any? {
+  let result = json_stringify_safe_js(obj)
+  if @core.is_nullish(result) {
+    Option::None
+  } else {
+    Some(result)
+  }
+}
+
+///|
+extern "js" fn json_stringify_safe_js(obj : @core.Any) -> @core.Any =
+  #|(obj) => {
+  #|  try {
+  #|    return JSON.stringify(obj);
+  #|  } catch (e) {
+  #|    return null;
+  #|  }
+  #|}
+
+///|
+/// Remove URL from cache array
+fn remove_url_from_cache(cache : @core.Any, url : String) -> @core.Any {
+  remove_url_from_cache_js(cache, url)
+}
+
+///|
+extern "js" fn remove_url_from_cache_js(
+  cache : @core.Any,
+  url : String,
+) -> @core.Any =
+  #|(cache, url) => {
+  #|  const arr = Array.isArray(cache) ? cache : [];
+  #|  for (let i = 0; i < arr.length; i++) {
+  #|    if (arr[i] && arr[i].url === url) {
+  #|      arr.splice(i, 1);
+  #|      break;
+  #|    }
+  #|  }
+  #|  return arr;
+  #|}
+
+///|
+/// Add new entry to cache (LRU - adds to end)
+fn add_to_cache(
+  cache : @core.Any,
+  url : String,
+  content : String,
+  title : String,
+  scroll : Int,
+) -> @core.Any {
+  add_to_cache_js(cache, url, content, title, scroll)
+}
+
+///|
+extern "js" fn add_to_cache_js(
+  cache : @core.Any,
+  url : String,
+  content : String,
+  title : String,
+  scroll : Int,
+) -> @core.Any =
+  #|(cache, url, content, title, scroll) => {
+  #|  const arr = Array.isArray(cache) ? cache : [];
+  #|  arr.push({ url, content, title, scroll });
+  #|  return arr;
+  #|}
+
+///|
+/// Limit cache to specified size (removes from beginning - oldest entries)
+fn limit_cache_size(cache : @core.Any, max_size : Int) -> @core.Any {
+  limit_cache_size_js(cache, max_size)
+}
+
+///|
+extern "js" fn limit_cache_size_js(
+  cache : @core.Any,
+  max_size : Int,
+) -> @core.Any =
+  #|(cache, max_size) => {
+  #|  const arr = Array.isArray(cache) ? cache : [];
+  #|  while (arr.length > max_size) {
+  #|    arr.shift();
+  #|  }
+  #|  return arr;
+  #|}
+
+///|
+/// Get array length
+fn array_length(arr : @core.Any) -> Int {
+  array_length_js(arr)
+}
+
+///|
+extern "js" fn array_length_js(arr : @core.Any) -> Int =
+  #|(arr) => (Array.isArray(arr) ? arr.length : 0)
+
+///|
+/// Find content in cache by URL
+fn find_in_cache(cache : @core.Any, url : String) -> @core.Any? {
+  let result = find_in_cache_js(cache, url)
+  if @core.is_nullish(result) {
+    Option::None
+  } else {
+    Some(result)
+  }
+}
+
+///|
+extern "js" fn find_in_cache_js(cache : @core.Any, url : String) -> @core.Any =
+  #|(cache, url) => {
+  #|  const arr = Array.isArray(cache) ? cache : [];
+  #|  for (let i = 0; i < arr.length; i++) {
+  #|    if (arr[i] && arr[i].url === url) {
+  #|      return arr[i].content || null;
+  #|    }
+  #|  }
+  #|  return null;
+  #|}
+
+///|
+/// Save cache with retry (shrinks if quota exceeded)
+fn save_cache_with_retry(cache : @core.Any) -> Unit {
+  let cache_len = array_length(cache)
+  if cache_len == 0 {
+    // Empty cache, remove it
+    session_storage_remove(HISTORY_CACHE_KEY)
+    return
+  }
+  match json_stringify_safe(cache) {
+    Some(json_str) =>
+      if not(session_storage_set(HISTORY_CACHE_KEY, json_str)) {
+        // Storage failed, try shrinking cache
+        if cache_len > 1 {
+          let shrunk = limit_cache_size(cache, cache_len - 1)
+          save_cache_with_retry(shrunk)
+        } else {
+          // Single item failed to save, remove cache entirely
+          session_storage_remove(HISTORY_CACHE_KEY)
+        }
+      }
+    None =>
+      // JSON stringify failed, remove cache entirely
+      session_storage_remove(HISTORY_CACHE_KEY)
+  }
+}
+
+///|
+/// Get cache array from sessionStorage
+fn get_cache_array() -> @core.Any {
+  let json = session_storage_get(HISTORY_CACHE_KEY)
+  if @core.is_nullish(json) {
+    @core.new_array()
+  } else {
+    let parsed = json_parse_safe_any(json)
+    if @core.is_nullish(parsed) {
+      @core.new_array()
+    } else {
+      parsed
+    }
+  }
+}
+
+///|
+extern "js" fn json_parse_safe_any(json_any : @core.Any) -> @core.Any =
+  #|(json_any) => {
+  #|  try {
+  #|    return JSON.parse(json_any);
+  #|  } catch (e) {
+  #|    return null;
+  #|  }
+  #|}
+
+///|
+/// Clean element innerHTML for history cache
+/// Cleans the content of the given element
+fn clean_element_for_history(element_any : @core.Any) -> String {
+  clean_element_for_history_js(element_any)
+}
+
+///|
+extern "js" fn clean_element_for_history_js(element_any : @core.Any) -> String =
+  #|(element) => {
+  #|  if (!element) return '';
+  #|  // Clone the element
+  #|  const clone = element.cloneNode(true);
+  #|  // Remove htmx-request class from all elements
+  #|  const requestElements = clone.querySelectorAll('.htmx-request');
+  #|  for (let i = 0; i < requestElements.length; i++) {
+  #|    requestElements[i].classList.remove('htmx-request');
+  #|  }
+  #|  // Remove disabled attribute from elements with data-disabled-by-htmx
+  #|  const disabledElements = clone.querySelectorAll('[data-disabled-by-htmx]');
+  #|  for (let i = 0; i < disabledElements.length; i++) {
+  #|    disabledElements[i].removeAttribute('disabled');
+  #|  }
+  #|  return clone.innerHTML;
+  #|}
+
+///|
+/// Save current page content to history cache
+pub fn save_to_history_cache(
+  url : String,
+  element_any : @core.Any,
+  title : String,
+) -> Unit {
+  if not(can_access_session_storage()) {
+    return
+  }
+  let cache_size = get_cache_size()
+  if cache_size <= 0 {
+    session_storage_remove(HISTORY_CACHE_KEY)
+    return
+  }
+  let normalized_url = normalize_path(url)
+
+  // Clean the HTML content from the given element
+  let content = clean_element_for_history(element_any)
+  let doc_title = if title == "" { get_document_title() } else { title }
+  let scroll = get_scroll_y()
+
+  // Get existing cache or initialize
+  let mut cache = get_cache_array()
+
+  // Remove existing entry for this URL (if any) - same URL overwrites
+  cache = remove_url_from_cache(cache, normalized_url)
+
+  // Add new entry
+  cache = add_to_cache(cache, normalized_url, content, doc_title, scroll)
+
+  // Limit to cache size
+  cache = limit_cache_size(cache, cache_size)
+
+  // Try to save, shrinking cache if needed
+  save_cache_with_retry(cache)
+}
+
+///|
+/// Get cached history content for a URL
+pub fn get_cached_history(url : String) -> String? {
+  if not(can_access_session_storage()) {
+    Option::None
+  } else {
+    let normalized_url = normalize_path(url)
+    let cache = get_cache_array()
+    match find_in_cache(cache, normalized_url) {
+      Some(result) =>
+        if @core.is_nullish(result) {
+          Option::None
+        } else {
+          Some(any_to_string(result))
+        }
+      None => Option::None
+    }
+  }
+}
+
+///|
+extern "js" fn any_to_string(any : @core.Any) -> String =
+  #|(any) => {
+  #|  if (typeof any === 'string') return any;
+  #|  return String(any);
+  #|}
+
+///|
+/// Get current location pathname + search
+fn location_pathname() -> String {
+  location_pathname_js()
+}
+
+///|
+extern "js" fn location_pathname_js() -> String =
+  #|() => location.pathname + location.search
+
+///|
+/// Reload the page
+fn location_reload(forced : Bool) -> Unit {
+  location_reload_js(forced)
+}
+
+///|
+extern "js" fn location_reload_js(forced : Bool) -> Unit =
+  #|(forced) => { window.location.reload(forced); }
+
+///|
+/// Set inner HTML of element (for history cache)
+fn set_inner_html_for_cache(element : @dom.Element, html : String) -> Unit {
+  set_inner_html_for_cache_js(element, html)
+}
+
+///|
+extern "js" fn set_inner_html_for_cache_js(
+  element : @dom.Element,
+  html : String,
+) -> Unit =
+  #|(element, html) => { element.innerHTML = html; }
+
+///|
+/// Process htmx content on element
+fn process_htmx_content(element_any : @core.Any) -> Unit {
+  process_htmx_content_js(element_any)
+}
+
+///|
+extern "js" fn process_htmx_content_js(element_any : @core.Any) -> Unit =
+  #|(element_any) => {
+  #|  if (window.htmx && window.htmx.process) {
+  #|    window.htmx.process(element_any);
+  #|  }
+  #|}
+
+///|
+/// Load history from server on cache miss
+fn load_from_server(path : String) -> Unit {
+  load_from_server_js(path)
+}
+
+///|
+extern "js" fn load_from_server_js(path : String) -> Unit =
+  #|(path) => {
+  #|  const xhr = new XMLHttpRequest();
+  #|  xhr.open('GET', path, true);
+  #|  xhr.setRequestHeader('HX-Request', 'true');
+  #|  xhr.setRequestHeader('HX-History-Restore-Request', 'true');
+  #|  xhr.setRequestHeader('HX-Current-URL', location.href);
+  #|  xhr.onload = function() {
+  #|    if (this.status >= 200 && this.status < 400) {
+  #|      const historyElt = document.querySelector('[hx-history-elt],[data-hx-history-elt]') || document.body;
+  #|      historyElt.innerHTML = this.response;
+  #|      if (window.htmx && window.htmx.process) {
+  #|        window.htmx.process(historyElt);
+  #|      }
+  #|    }
+  #|  };
+  #|  xhr.send();
+  #|}
+
+///|
+/// Restore history from cache or server
+pub fn restore_history(path : String) -> Unit {
+  let cache_path = if path == "" { location_pathname() } else { path }
+  match get_cached_history(cache_path) {
+    Some(content) => {
+      // Cache hit - restore from cache
+      let history_elt = get_history_element()
+      set_inner_html_for_cache(history_elt, content)
+
+      // Process new content
+      process_htmx_content(history_elt.as_any())
+    }
+    None =>
+      // Cache miss
+      if get_refresh_on_history_miss() {
+        location_reload(true)
+      } else {
+        load_from_server(cache_path)
+      }
+  }
+}

--- a/src/htmx/pkg.generated.mbti
+++ b/src/htmx/pkg.generated.mbti
@@ -31,6 +31,8 @@ pub fn find_oob_target(@dom.Element, OobSpec) -> @dom.Element?
 
 pub fn find_targets_by_selector(@dom.Element, String) -> Array[@dom.Element]
 
+pub fn get_cached_history(String) -> String?
+
 pub fn get_disabled_elt(@dom.Element) -> String?
 
 pub fn get_form_data(@dom.Element) -> @http.FormData?
@@ -61,6 +63,8 @@ pub fn morph(@dom.Element, String) -> Unit
 
 pub fn morph_element(@dom.Element, @dom.Element) -> Unit
 
+pub fn normalize_path(String) -> String
+
 pub fn parse_oob_spec(String) -> OobSpec
 
 pub fn parse_trigger(String) -> TriggerDef
@@ -88,6 +92,10 @@ pub fn request_with_form_async(String, HttpMethod, @http.FormData?, @dom.Element
 pub async fn request_with_form_safe(String, HttpMethod, @http.FormData?, @dom.Element?) -> String? noraise
 
 pub fn request_with_form_sync(String, HttpMethod, @http.FormData?, @dom.Element?) -> String?
+
+pub fn restore_history(String) -> Unit
+
+pub fn save_to_history_cache(String, @core.Any, String) -> Unit
 
 pub fn show_indicators(Array[@dom.Element]) -> Unit
 

--- a/src/htmx/processor.mbt
+++ b/src/htmx/processor.mbt
@@ -287,6 +287,14 @@ extern "js" fn create_response_callback(
   #|      if (push_val && push_val !== "false") {
   #|        const dest_url = push_val === "true" ? url : push_val;
   #|        history.pushState(null, '', dest_url);
+  #|        // Save to history cache
+  #|        if (window.htmx && window.htmx._ && typeof window.htmx._ === 'function') {
+  #|          try {
+  #|            window.htmx._('saveToHistoryCache')(dest_url, target);
+  #|          } catch (e) {
+  #|            // Ignore errors
+  #|          }
+  #|        }
   #|      }
   #|    }
   #|  };


### PR DESCRIPTION
## Summary

This PR implements the history cache functionality for htmx.mbt, addressing Issue #1.

## Changes

- **Add `src/htmx/history_cache.mbt`**: Core history cache implementation
  - `save_to_history_cache(url, element, title)`: Save page content to sessionStorage
  - `get_cached_history(url)`: Retrieve cached content for a URL
  - `restore_history(path)`: Restore page from cache or server
  - `normalize_path(path)`: Normalize URLs for cache keys

- **Modify `cmd/htmx_test/main.mbt`**: Wire up history cache functions
  - Add dispatch in `internal_any` for `saveToHistoryCache`, `getCachedHistory`, `restoreHistory`, `normalizePath`
  - Add `historyCacheSize` and `refreshOnHistoryMiss` config options

- **Modify `src/htmx/processor.mbt`**: Save to history cache on hx-push-url

## Features

- Session storage backed history cache (max 10 entries, LRU)
- Same URL overwrites existing entry
- Removes `htmx-request` class and `disabled` attribute with `data-disabled-by-htmx` before caching
- Graceful error handling for sessionStorage access and JSON parsing
- Configurable cache size and refresh-on-miss behavior

## Test Results

- 16 tests passed in `test/attributes/hx-push-url.js`
- Core history cache functionality working

## Checklist

- [x] `cmd/htmx_test/main.mbt` の `internal_any` にディスパッチを追加
- [x] history cache 実装を `src/htmx/history_cache.mbt` に追加
- [x] sessionStorage に JSON 配列で保存（最大10件、同一 URL は上書き）
- [x] `data-disabled-by-htmx` / `htmx-request` などサポート用クラスの除去
- [x] sessionStorage が無効/例外時は no-op で落ちない
- [x] JSON 破損時は初期化して継続
- [x] `restoreHistory` で `htmx.config.refreshOnHistoryMiss` と `location.reload()` を尊重
- [x] `moon info && moon fmt` → commit

Refs: #1