### PR TITLE
fix: normalizePath fallback for invalid URLs (Issue #5)

### DIFF
--- a/src/htmx/history_cache.mbt
+++ b/src/htmx/history_cache.mbt
@@ -16,16 +16,19 @@ pub fn normalize_path(path : String) -> String {
 ///|
 extern "js" fn normalize_path_impl(path : String) -> String =
   #|(path) => {
+  #|  let parsed = false;
   #|  try {
   #|    const url = new URL(path, 'http://x');
   #|    if (url) {
   #|      path = url.pathname + url.search;
+  #|      parsed = true;
   #|    }
   #|  } catch (e) {
-  #|    // If URL parsing fails, use path as-is
+  #|    // If URL parsing fails, use path as-is (no trailing slash removal)
   #|  }
   #|  // Remove trailing slash unless it's the index
-  #|  if (path !== '/') {
+  #|  // Only apply this for valid URLs that were parsed successfully
+  #|  if (parsed && path !== '/') {
   #|    path = path.replace(/\/+$/, '');
   #|  }
   #|  return path;

--- a/test/attributes/hx-push-url.js
+++ b/test/attributes/hx-push-url.js
@@ -273,7 +273,7 @@ describe('hx-push-url attribute', function() {
     })
   }
 
-  it.skip('normalizePath falls back to no normalization if path not valid URL', function() {
+  it('normalizePath falls back to no normalization if path not valid URL', function() {
     // path normalization has a bug breaking it right now preventing this test
     htmx._('saveToHistoryCache')('http://', make('<div>'))
     htmx._('saveToHistoryCache')('http//', make('<div>'))


### PR DESCRIPTION
## Summary
- Add \`parsed\` flag to track successful URL parsing in \`normalizePath\`
- Only remove trailing slashes for valid URLs that were successfully parsed
- Unskip the test "normalizePath falls back to no normalization if path not valid URL"

## Test plan
- ✓ \`normalizePath falls back to no normalization if path not valid URL\` - PASSES
  - \`http://\` (invalid) → kept as \`http://\`
  - \`http//\` (valid) → normalized to \`/http\`

Fixes #5