### PR TITLE
feat: implement hx-inherit attribute support

### DIFF
--- a/src/htmx/attributes.mbt
+++ b/src/htmx/attributes.mbt
@@ -570,3 +570,183 @@ pub fn get_indicator_elements(element : @dom.Element) -> Array[@dom.Element] {
     }
   }
 }
+
+///|
+/// Check if htmx.config.disableInheritance is true
+extern "js" fn get_disable_inheritance() -> Bool =
+  #|() => {
+  #|  try {
+  #|    return window.htmx && window.htmx.config && window.htmx.config.disableInheritance === true;
+  #|  } catch(e) {
+  #|    return false;
+  #|  }
+  #|}
+
+///|
+/// Get the hx-inherit attribute value (checks both hx-inherit and data-hx-inherit)
+pub fn get_hx_inherit(element : @dom.Element) -> String? {
+  match element.getAttribute("hx-inherit") {
+    Some(value) => Some(value)
+    Option::None => element.getAttribute("data-hx-inherit")
+  }
+}
+
+///|
+/// Parse hx-inherit value to get array of attribute names to inherit
+extern "js" fn parse_hx_inherit(value : String) -> @core.Any =
+  #|(value) => {
+  #|  if (!value || value === '*') return ['*'];
+  #|  return value.split(/\s+/).filter(s => s.length > 0);
+  #|}
+
+///|
+/// Check if a specific attribute should be inherited from parent
+/// Returns Some(value) if the attribute should be inherited, None otherwise
+fn should_inherit_attribute(
+  element : @dom.Element,
+  attr_name : String,
+) -> String? {
+  // If disableInheritance is false, inheritance is enabled by default
+  let disabled = get_disable_inheritance()
+  if not(disabled) {
+    // Inheritance is enabled by default, check parents
+    return find_inherited_attribute(element, attr_name)
+  }
+
+  // Inheritance is disabled by default, only inherit if parent has hx-inherit
+  find_inherited_attribute_with_check(element, attr_name)
+}
+
+///|
+/// Find inherited attribute from parent (when disableInheritance = false)
+fn find_inherited_attribute(
+  element : @dom.Element,
+  attr_name : String,
+) -> String? {
+  match get_parent_element(element) {
+    Some(parent) => {
+      // Check if parent has the attribute
+      match parent.getAttribute(attr_name) {
+        Some(value) => Some(value)
+        Option::None => {
+          // Check for data-hx-* prefix
+          let data_attr = with_data_prefix(attr_name)
+          match parent.getAttribute(data_attr) {
+            Some(value) => Some(value)
+            Option::None => find_inherited_attribute(parent, attr_name)
+          }
+        }
+      }
+    }
+    Option::None => Option::None
+  }
+}
+
+///|
+/// Find inherited attribute with hx-inherit check (when disableInheritance = true)
+fn find_inherited_attribute_with_check(
+  element : @dom.Element,
+  attr_name : String,
+) -> String? {
+  match get_parent_element(element) {
+    Some(parent) => {
+      // Check if parent has hx-inherit
+      match get_hx_inherit(parent) {
+        Some(inherit_value) => {
+          // Parse hx-inherit value
+          let inherit_array = parse_hx_inherit(inherit_value)
+          let inherits_all = check_inherits_all(inherit_array)
+          let inherits_this = check_includes_attribute(inherit_array, attr_name)
+
+          if inherits_all || inherits_this {
+            // Parent allows inheriting this attribute
+            match parent.getAttribute(attr_name) {
+              Some(value) => Some(value)
+              Option::None => {
+                // Check for data-hx-* prefix
+                let data_attr = with_data_prefix(attr_name)
+                match parent.getAttribute(data_attr) {
+                  Some(value) => Some(value)
+                  Option::None => find_inherited_attribute_with_check(parent, attr_name)
+                }
+              }
+            }
+          } else {
+            // Parent doesn't allow inheriting this attribute, keep searching up
+            find_inherited_attribute_with_check(parent, attr_name)
+          }
+        }
+        Option::None => find_inherited_attribute_with_check(parent, attr_name)
+      }
+    }
+    Option::None => Option::None
+  }
+}
+
+///|
+/// Check if hx-inherit array contains '*' (inherit all)
+extern "js" fn check_inherits_all(arr : @core.Any) -> Bool =
+  #|(arr) => {
+  #|  if (!arr || !Array.isArray(arr)) return false;
+  #|  return arr.includes('*');
+  #|}
+
+///|
+/// Check if hx-inherit array includes a specific attribute
+extern "js" fn check_includes_attribute(arr : @core.Any, attr : String) -> Bool =
+  #|(arr, attr) => {
+  #|  if (!arr || !Array.isArray(arr)) return false;
+  #|  return arr.includes(attr);
+  #|}
+
+///|
+/// Get target element with inheritance support
+pub fn get_target_with_inherit(element : @dom.Element) -> @dom.Element {
+  let target_attr = hx_target()
+  let result = match element.getAttribute(target_attr) {
+    Some(selector) => Some(selector)
+    Option::None => element.getAttribute(with_data_prefix(target_attr))
+  }
+
+  match result {
+    Some(selector) => {
+      match parse_extended_target(element, selector) {
+        Some(target) => target
+        None => element
+      }
+    }
+    None => {
+      // Try to inherit hx-target from parent
+      match should_inherit_attribute(element, target_attr) {
+        Some(inherited_selector) => {
+          match parse_extended_target(element, inherited_selector) {
+            Some(target) => target
+            None => element
+          }
+        }
+        None => element
+      }
+    }
+  }
+}
+
+///|
+/// Get swap style with inheritance support
+pub fn get_swap_style_with_inherit(element : @dom.Element) -> SwapStyle {
+  let swap_attr = hx_swap()
+  match element.getAttribute(swap_attr) {
+    Some(value) => SwapStyle::parse(value)
+    Option::None => {
+      match element.getAttribute(with_data_prefix(swap_attr)) {
+        Some(value) => SwapStyle::parse(value)
+        Option::None => {
+          // Try to inherit hx-swap from parent
+          match should_inherit_attribute(element, swap_attr) {
+            Some(inherited_value) => SwapStyle::parse(inherited_value)
+            None => SwapStyle::InnerHTML
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/htmx/processor.mbt
+++ b/src/htmx/processor.mbt
@@ -20,9 +20,10 @@ fn process_element_with_trigger(
     return
   }
 
-  // Get target and swap style
-  let target = get_target(element)
-  let swap_style = get_swap_style(element)
+  // Get target and swap style (with inheritance support)
+  let target = get_target_with_inherit(element)
+  let swap_style = get_swap_style_with_inherit(element)
+  let swap_style_str = swap_style.to_htmx_string()
 
   // Get disabled elements before request
   let disabled_elements = match get_disabled_elt(element) {
@@ -76,7 +77,7 @@ fn process_element_with_trigger(
 
   // Create callback for async response handling
   let callback = create_response_callback(
-    element, target, swap_style, url, disabled_elements, indicator_elements,
+    element, target, swap_style_str, url, disabled_elements, indicator_elements,
   )
 
   // Handle form data for POST/PUT/PATCH vs GET/DELETE
@@ -111,12 +112,12 @@ fn process_element_with_trigger(
 extern "js" fn create_response_callback(
   element : @dom.Element,
   target : @dom.Element,
-  swap_style : SwapStyle,
+  swap_style_str : String,
   url : String,
   disabled_elements : Array[@dom.Element],
   indicator_elements : Array[@dom.Element],
 ) -> @core.Any =
-  #|(element, target, swap_style, url, disabled_elements, indicator_elements) => {
+  #|(element, target, swap_style_str, url, disabled_elements, indicator_elements) => {
   #|  return function(responseText) {
   #|    // Hide indicators after request
   #|    if (indicator_elements.length > 0) {
@@ -158,9 +159,12 @@ extern "js" fn create_response_callback(
   #|      const defaultSwapStyle = typeof config.defaultSwapStyle === 'string'
   #|        ? config.defaultSwapStyle
   #|        : 'innerHTML';
-  #|      const swapStyle = swapSpec && typeof swapSpec.swapStyle === 'string'
-  #|        ? swapSpec.swapStyle
-  #|        : defaultSwapStyle;
+  #|      // Use the passed swap_style_str (with inheritance support) as priority
+  #|      const swapStyle = swap_style_str && typeof swap_style_str === 'string'
+  #|        ? swap_style_str
+  #|        : (swapSpec && typeof swapSpec.swapStyle === 'string'
+  #|          ? swapSpec.swapStyle
+  #|          : defaultSwapStyle);
   #|      const swapDelay = swapSpec && typeof swapSpec.swapDelay === 'number' ? swapSpec.swapDelay : 0;
   #|      const settleDelay = swapSpec && typeof swapSpec.settleDelay === 'number'
   #|        ? swapSpec.settleDelay

--- a/src/htmx/swap.mbt
+++ b/src/htmx/swap.mbt
@@ -360,6 +360,22 @@ pub fn SwapStyle::parse(value : String) -> SwapStyle {
 }
 
 ///|
+/// Convert SwapStyle to lowercase string for htmx compatibility
+pub fn SwapStyle::to_htmx_string(self : SwapStyle) -> String {
+  match self {
+    InnerHTML => "innerHTML"
+    OuterHTML => "outerHTML"
+    BeforeBegin => "beforebegin"
+    AfterBegin => "afterbegin"
+    BeforeEnd => "beforeend"
+    AfterEnd => "afterend"
+    Delete => "delete"
+    None => "none"
+    Morph => "morph"
+  }
+}
+
+///|
 /// Get position string for insertAdjacentHTML
 fn SwapStyle::to_position(self : SwapStyle) -> String? {
   match self {


### PR DESCRIPTION
## Summary
- Implement the `hx-inherit` attribute that allows child elements to inherit htmx attributes from their parent elements
- Add `get_hx_inherit()` to check for hx-inherit attribute on parent elements
- Add `should_inherit_attribute()` to determine if an attribute should be inherited based on `htmx.config.disableInheritance` and parent's `hx-inherit` value
- Add `get_target_with_inherit()` and `get_swap_style_with_inherit()` functions that check parent elements for inheritable attributes
- Add `SwapStyle::to_htmx_string()` for proper string conversion (innerHTML, outerHTML, etc.)
- Update processor to use inherited swap style as priority over element's own attribute

## Test plan
- [x] All 5 tests in `test/attributes/hx-inherit.js` pass
  - can disable inheritance
  - can enable inheritance for all
  - can enable inheritance by name
  - can enable inheritance by name (bad name, no inheritance)
  - can enable inheritance by name with multiple attributes

🤖 Generated with [Claude Code](https://claude.com/claude-code)