### PR TITLE
fix(hx-vals): improve test pass rate from 19/26 to 24/26

### DIFF
--- a/src/htmx/form.mbt
+++ b/src/htmx/form.mbt
@@ -12,27 +12,60 @@ extern "js" fn new_form_data() -> @http.FormData =
   #|() => new FormData()
 
 ///|
-/// Get all form input values as key-value pairs
+/// Get all form input values as key-value pairs (includes element itself if it's an input)
 pub fn collect_input_values(form : @dom.Element) -> Array[(String, String)] {
-  let result : Array[(String, String)] = []
-
-  // Query all input, select, textarea elements
-  let inputs = form.querySelectorAll("input, select, textarea")
-  for element in inputs {
-    match element.getAttribute("name") {
-      Some(name) if name.length() > 0 => {
-        // Get value based on element type
-        let value = get_input_value(element)
-        match value {
-          Some(v) => result.push((name, v))
-          None => ()
-        }
-      }
-      _ => ()
-    }
-  }
-  result
+  collect_input_values_inner(form)
 }
+
+///|
+/// Internal FFI to collect input values
+extern "js" fn collect_input_values_inner(form : @dom.Element) -> Array[(String, String)] =
+  #|(form) => {
+  #|  const result = [];
+  #|
+  #|  // Helper to process a single element
+  #|  const processElement = (el) => {
+  #|    if (!el || !el.getAttribute) return;
+  #|    const name = el.getAttribute('name');
+  #|    if (name && name.length > 0) {
+  #|      const tag = el.tagName && el.tagName.toUpperCase();
+  #|      if (tag === 'INPUT') {
+  #|        const type = (el.getAttribute('type') || 'text').toLowerCase();
+  #|        if (type === 'checkbox' || type === 'radio') {
+  #|          if (el.checked) {
+  #|            const value = el.getAttribute('value') || 'on';
+  #|            result.push({ _0: name, _1: value });
+  #|          }
+  #|        } else if (type === 'file') {
+  #|          // Skip file inputs
+  #|        } else {
+  #|          const value = el.value || '';
+  #|          result.push([name, value]);
+  #|        }
+  #|      } else if (tag === 'SELECT' || tag === 'TEXTAREA') {
+  #|        const value = el.value || '';
+  #|        result.push([name, value]);
+  #|      }
+  #|    }
+  #|  };
+  #|
+  #|  // Process the form element itself if it's an input
+  #|  const formTag = form.tagName && form.tagName.toUpperCase();
+  #|  if (formTag === 'INPUT' || formTag === 'SELECT' || formTag === 'TEXTAREA') {
+  #|    processElement(form);
+  #|  }
+  #|
+  #|  // Process all child input elements
+  #|  const inputs = form.querySelectorAll('input, select, textarea');
+  #|  console.log('[htmx.mbt FORM] collect_input_values on', form.tagName, 'found', inputs.length, 'inputs');
+  #|  for (const el of inputs) {
+  #|    processElement(el);
+  #|  }
+  #|
+  #|  console.log('[htmx.mbt FORM] collected result:', result);
+  #|  // Return as MoonBit Array structure
+  #|  return { buf: result, start: 0, end: result.length };
+  #|}
 
 ///|
 /// Get value from an input element

--- a/src/htmx/processor.mbt
+++ b/src/htmx/processor.mbt
@@ -9,15 +9,31 @@ extern "js" fn values_to_js_object(
   values : Array[(String, String)],
 ) -> @core.Any =
   #|(values) => {
+  #|  console.log('[htmx.mbt PROCESSOR] values_to_js_object input:', values);
   #|  const obj = {};
+  #|  // Handle both MoonBit Array structure and plain JavaScript array
   #|  if (values && values.buf) {
+  #|    // MoonBit Array structure
   #|    for (let i = values.start || 0; i < (values.end || values.buf.length); i++) {
   #|      const entry = values.buf[i];
-  #|      if (entry && entry._0 !== undefined) {
-  #|        obj[entry._0] = entry._1;
+  #|      // Handle both { _0: key, _1: value } and [key, value] formats
+  #|      if (entry) {
+  #|        const key = entry._0 !== undefined ? entry._0 : (entry[0] !== undefined ? entry[0] : null);
+  #|        const val = entry._1 !== undefined ? entry._1 : (entry[1] !== undefined ? entry[1] : null);
+  #|        if (key !== null) {
+  #|          obj[key] = val;
+  #|        }
+  #|      }
+  #|    }
+  #|  } else if (Array.isArray(values)) {
+  #|    // Plain JavaScript array
+  #|    for (const entry of values) {
+  #|      if (entry && entry.length >= 2) {
+  #|        obj[entry[0]] = entry[1];
   #|      }
   #|    }
   #|  }
+  #|  console.log('[htmx.mbt PROCESSOR] values_to_js_object output:', obj);
   #|  return obj;
   #|}
 
@@ -25,6 +41,7 @@ extern "js" fn values_to_js_object(
 /// Merge source object into target object
 extern "js" fn merge_objects(target : @core.Any, source : @core.Any) -> Unit =
   #|(target, source) => {
+  #|  console.log('[htmx.mbt PROCESSOR] merge_objects - target before:', JSON.stringify(target), 'source:', JSON.stringify(source));
   #|  if (target && source) {
   #|    for (const key in source) {
   #|      if (source.hasOwnProperty(key)) {
@@ -32,6 +49,7 @@ extern "js" fn merge_objects(target : @core.Any, source : @core.Any) -> Unit =
   #|      }
   #|    }
   #|  }
+  #|  console.log('[htmx.mbt PROCESSOR] merge_objects - target after:', JSON.stringify(target));
   #|}
 
 ///|
@@ -56,6 +74,7 @@ extern "js" fn js_object_to_map(obj : @core.Any) -> Map[String, String] =
 fn process_element_with_trigger(
   element : @dom.Element,
   trigger_el : @dom.Element?,
+  event : @core.Any?,
 ) -> Unit {
   let trigger_tag = match trigger_el {
     Some(el) => el.tagName()
@@ -166,7 +185,7 @@ fn process_element_with_trigger(
   )
 
   // Collect hx-vars/hx-vals from element and parents
-  let expression_vars = get_expression_vars(Some(element), None)
+  let expression_vars = get_expression_vars(Some(element), event)
 
   // Fire htmx:config-request event to allow modification of parameters
   // Collect input values for the event
@@ -689,8 +708,8 @@ extern "js" fn create_response_callback(
 
 ///|
 /// Wrapper for process element (kept for API compatibility)
-fn process_element(element : @dom.Element) -> Unit {
-  process_element_with_trigger(element, None)
+fn process_element(element : @dom.Element, event : @core.Any?) -> Unit {
+  process_element_with_trigger(element, None, event)
 }
 
 ///|
@@ -749,7 +768,7 @@ fn handle_click(evt : @core.Any) -> Unit {
               // not explicit user action of clicking a submit button
               event.preventDefault()
               // Pass the button as submitter for formnovalidate check
-              process_element_with_trigger(form, Some(target_el))
+              process_element_with_trigger(form, Some(target_el), Some(evt))
               return
             }
             None => ()
@@ -771,7 +790,7 @@ fn handle_click(evt : @core.Any) -> Unit {
       let trigger = get_trigger_event(htmx_el)
       if trigger == "click" || trigger == "load" {
         event.preventDefault()
-        process_element_with_trigger(htmx_el, Some(target_el))
+        process_element_with_trigger(htmx_el, Some(target_el), Some(evt))
       }
     }
     Option::None => ()
@@ -788,7 +807,7 @@ fn handle_change(evt : @core.Any) -> Unit {
       let trigger = get_trigger_event(htmx_el)
       if trigger == "change" {
         event.preventDefault()
-        process_element(htmx_el)
+        process_element(htmx_el, Some(evt))
       }
     }
     Option::None => ()
@@ -812,7 +831,7 @@ fn handle_submit(evt : @core.Any) -> Unit {
       if trigger == "submit" {
         event.preventDefault()
         // Pass submitter for formnovalidate check
-        process_element_with_trigger(htmx_el, submitter)
+        process_element_with_trigger(htmx_el, submitter, Some(evt))
       }
     }
     Option::None => ()

--- a/src/htmx/request.mbt
+++ b/src/htmx/request.mbt
@@ -304,6 +304,8 @@ extern "js" fn request_with_form_async_callback(
   #|      params.push(encodeURIComponent(key) + '=' + encodeURIComponent(value));
   #|    }
   #|    body = params.join('&');
+  #|    // Set Content-Type for URL-encoded body
+  #|    xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
   #|  }
   #|
   #|  xhr.send(body);

--- a/src/htmx/vars.mbt
+++ b/src/htmx/vars.mbt
@@ -170,7 +170,17 @@ extern "js" fn get_expression_vars_inner(
   #|  const entries = Object.entries(result);
   #|  const buf = [];
   #|  for (const [k, v] of entries) {
-  #|    buf.push({ _0: k, _1: String(v) });
+  #|    let strValue;
+  #|    // Convert objects to JSON string, other values to string
+  #|    // null becomes 'null' string for compatibility
+  #|    if (v === null) {
+  #|      strValue = 'null';
+  #|    } else if (typeof v === 'object') {
+  #|      strValue = JSON.stringify(v);
+  #|    } else {
+  #|      strValue = String(v);
+  #|    }
+  #|    buf.push({ _0: k, _1: strValue });
   #|  }
   #|  return { buf: buf, start: 0, end: buf.length };
   #|}


### PR DESCRIPTION
## Summary

Fixes #34 - improve test pass rate for `test/attributes/hx-vals.js` from 19/26 to 24/26.

## Changes

### vars.mbt
- **Object value JSON encoding**: Values that are objects (including nested objects) are now properly encoded as JSON strings instead of `"[object Object]"` or `undefined`
- **Null handling**: `null` values are now encoded as the string `"null"` for compatibility

### processor.mbt
- **Event passing**: The `event` parameter is now passed to `get_expression_vars()`, enabling `js:` expressions to access the event object
- **Input value collection**: The element itself is now processed for input values, not just child elements

### form.mbt
- **Input element self-collection**: Modified `collect_input_values_inner()` to process the form element itself if it's an input/select/textarea element
- **MoonBit Array structure**: Returns values in MoonBit Array format for proper FFI conversion

### request.mbt
- **Content-Type header**: Sets `Content-Type: application/x-www-form-urlencoded` when converting FormData to URL-encoded string for test compatibility

## Fixed Tests

- ✅ `hx-vals treats objects as JSON`
- ✅ `hx-vals works with object values`
- ✅ `using js: with hx-vals has event available`

## Remaining Failures (2)

- ❌ `unsetting hx-vals maintains input values` - `find_htmx_element()` returns parent DIV instead of INPUT element
- ❌ `using js: with hx-vals has event available when used with a delay` - delay trigger modifier not yet implemented

## Test Results

```
Chrome: |██████████████████████████████| 1/1 test files | 24 passed, 2 failed
```