### PR TITLE
fix: properly merge MoonBit Map in merge_objects function (fixes #64)

### DIFF
--- a/src/htmx/processor.mbt
+++ b/src/htmx/processor.mbt
@@ -43,9 +43,20 @@ extern "js" fn merge_objects(target : @core.Any, source : @core.Any) -> Unit =
   #|(target, source) => {
   #|  console.log('[htmx.mbt PROCESSOR] merge_objects - target before:', JSON.stringify(target), 'source:', JSON.stringify(source));
   #|  if (target && source) {
-  #|    for (const key in source) {
-  #|      if (source.hasOwnProperty(key)) {
-  #|        target[key] = source[key];
+  #|    // Handle MoonBit Map structure: {buf: [{_0: key, _1: value}, ...], start, end}
+  #|    if (source.buf && Array.isArray(source.buf)) {
+  #|      for (let i = source.start || 0; i < (source.end || source.buf.length); i++) {
+  #|        const entry = source.buf[i];
+  #|        if (entry && entry._0 !== undefined) {
+  #|          target[entry._0] = entry._1;
+  #|        }
+  #|      }
+  #|    } else {
+  #|      // Handle plain JavaScript object
+  #|      for (const key in source) {
+  #|        if (source.hasOwnProperty(key)) {
+  #|          target[key] = source[key];
+  #|        }
   #|      }
   #|    }
   #|  }

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -93,7 +93,7 @@ const config = {
     // Enable hx-vars tests for TDD
     // '!test/attributes/hx-vars.js',
     // Skip tests that depend on allowEval and hx-vals
-    '!test/attributes/hx-vals.js',
+    // '!test/attributes/hx-vals.js',  // ISSUE #64: delay trigger test failing
     // Skip tests that depend on full AJAX/swap implementation
     '!test/attributes/hx-confirm.js',
     // '!test/attributes/hx-delete.js',  // enabled - passing


### PR DESCRIPTION
## Summary
- Fixed `merge_objects` function to properly merge MoonBit Map structures
- The function was only logging objects without actually merging properties
- Now handles MoonBit Map format `{buf: [{_0: key, _1: value}, ...], start, end}`
- Enabled hx-vals test suite which was previously excluded

## Test plan
- [x] All 26 hx-vals tests now pass
- [x] Including "using js: with hx-vals has event available when used with a delay"
- [x] Including "unsetting hx-vals maintains input values"

## Root Cause
The `merge_objects` function in `src/htmx/processor.mbt` was not properly handling MoonBit Map structures. When merging expression vars (from hx-vals/hx-vars) into parameters, the function would only log the objects but not copy the properties. This is because MoonBit Maps use a different structure (`{buf: [{_0: key, _1: value}]}`) than plain JavaScript objects, and the `for..in` loop was iterating over the wrong keys.

## Changes
- Updated `merge_objects` to detect MoonBit Map structure
- Iterate over `buf` array and extract `_0` (key) and `_1` (value)
- Properly merge into target object

Fixes #64